### PR TITLE
ci: force Node 24 for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,13 @@ on:
     pull_request:
         branches: [main, develop]
 
+env:
+    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
     validate:
         name: Validate Extension
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
             - uses: actions/checkout@v6
               with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,16 @@ on:
         tags:
             - "v*"
 
+env:
+    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
     contents: write
 
 jobs:
     build:
         name: Build Release Artifact
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
             - uses: actions/checkout@v6
               with:
@@ -45,7 +48,7 @@ jobs:
     release:
         name: Create Release
         needs: build
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
             - uses: actions/download-artifact@v6
               with:


### PR DESCRIPTION
## Summary
- force JavaScript GitHub Actions to run on Node 24
- pin workflow runners to ubuntu-24.04
- clean up the leftover local `server/` directory during follow-up work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure configurations to use newer environment settings for improved build reliability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->