### PR TITLE
ci: install bun without setup action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
     pull_request:
         branches: [main, develop]
 
-env:
-    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
     validate:
         name: Validate Extension
@@ -18,9 +15,10 @@ jobs:
               with:
                   submodules: recursive
 
-            - uses: oven-sh/setup-bun@v2
-              with:
-                  bun-version: latest
+            - name: Install Bun
+              run: |
+                  curl -fsSL https://bun.sh/install | bash
+                  echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
 
             - name: Install dependencies
               run: bun install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,6 @@ on:
         tags:
             - "v*"
 
-env:
-    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 permissions:
     contents: write
 
@@ -20,9 +17,10 @@ jobs:
               with:
                   submodules: recursive
 
-            - uses: oven-sh/setup-bun@v2
-              with:
-                  bun-version: latest
+            - name: Install Bun
+              run: |
+                  curl -fsSL https://bun.sh/install | bash
+                  echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
 
             - name: Install dependencies
               run: bun install


### PR DESCRIPTION
## Summary
- remove `oven-sh/setup-bun` from workflows
- install Bun via the official shell installer instead
- keep workflows on ubuntu-24.04 to stay on a Node 24-capable runner base
